### PR TITLE
Update to emergency contact placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,30 @@
                         </div>
                         <div class="section paragraph--link-list" data-digest-content>
                             <div class="section__header">
+                                <h2 class="section__title">Emergency Contacts</h2>
+                            </div>
+                            <ul class="link-list__list">
+                                <li class="link-list__item">
+                                    <div class="link-list__box">
+                                        <a class="link-list__link" href="tel:+8024435911">Call Public Safety in VT at (802) 443-5911</a>
+                                        <p class="link-list__info">Or email <a href="mailto:publicsafety@middlebury.edu">publicsafety@middlebury.edu</a>.</p>
+                                    </div>
+                                </li>
+                                <li class="link-list__item">
+                                    <div class="link-list__box">
+                                        <a class="link-list__link" href="tel:+18316474153">Call Campus Security in CA at (831) 647-4153</a>
+                                    </div>
+                                </li>
+                                <li class="link-list__item">
+                                    <div class="link-list__box">
+                                        <a class="link-list__link" href="tel:+8024435911">Call Admissions at (802) 443-3000</a>
+                                        <p class="link-list__info">Or email <a href="mailto:admissions@middlebury.edu">admissions@middlebury.edu</a>.</p>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="section paragraph--link-list" data-digest-content>
+                            <div class="section__header">
                                 <h2 class="section__title">Quick Links</h2>
                                 <p class="section__text">These resources are hosted separately and may still be available.</p>
                             </div>
@@ -119,30 +143,6 @@
                                 <li class="link-list__item">
                                     <div class="link-list__box">
                                         <a class="link-list__link" href="https://middlebury.zoom.us/j/8024432200?pwd=K2RWTnd0TVhDc0ZtUHZQcXFZUElzdz09">On Zoom</a>
-                                    </div>
-                                </li>
-                            </ul>
-                        </div>
-                        <div class="section paragraph--link-list" data-digest-content>
-                            <div class="section__header">
-                                <h2 class="section__title">Other Contacts</h2>
-                            </div>
-                            <ul class="link-list__list">
-                                <li class="link-list__item">
-                                    <div class="link-list__box">
-                                        <a class="link-list__link" href="tel:+8024435911">Call Public Safety in VT at (802) 443-5911</a>
-                                        <p class="link-list__info">Or email <a href="mailto:publicsafety@middlebury.edu">publicsafety@middlebury.edu</a>.</p>
-                                    </div>
-                                </li>
-                                <li class="link-list__item">
-                                    <div class="link-list__box">
-                                        <a class="link-list__link" href="tel:+18316474153">Call Campus Security in CA at (831) 647-4153</a>
-                                    </div>
-                                </li>
-                                <li class="link-list__item">
-                                    <div class="link-list__box">
-                                        <a class="link-list__link" href="tel:+8024435911">Call Admissions at (802) 443-3000</a>
-                                        <p class="link-list__info">Or email <a href="mailto:admissions@middlebury.edu">admissions@middlebury.edu</a>.</p>
                                     </div>
                                 </li>
                             </ul>


### PR DESCRIPTION
Moved the emergency contact info up to the top of the page - renamed it to be emergency contact instead of other contact.